### PR TITLE
Add Requirements section to README for Linux and macOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,50 @@ devices.
 For help, see the built-in [Usage Instructions](usage.md).
 
 
+## Requirements
+
+On Windows the standard Python installation is sufficient.  All other
+dependencies are listed in `requirements.txt`.  To fully leverage the
+command line in Windows you may want to install [Terminal 2][4] and
+[Git Bash][2].
+
+On Linux and macOS, however, your default Python3 installation may not
+have the full Python distribution.
+
+Debian/Ubuntu/Linux Mint:
+
+```bash
+~$ sudo apt-get install python3-tk
+```
+
+RedHat/Fedora:
+
+```bash
+~$ sudo dnf install python3-tkinter
+```
+
+macOS:
+
+```bash
+~$ brew install python-tk
+```
+
+
 ## Cloning
 
 Use git to clone this repository (the green <> Code button):
 
 ```bash
-git clone https://github.com/addiva-elektronik/netconf-client.git
+~$ cd src/
+~/src$ git clone https://github.com/addiva-elektronik/netconf-client.git
+~/src$ cd netconf-client/
 ```
 
 ## Setup
 
-It is recommended to use Python3 virtual environment for 3rd party
-software.  This ensures proper versions of all dependencies are used,
-without leaking over to other programs.
+It is recommended to use Python3 virtual environment (venv) for 3rd
+party software.  This ensures proper versions of all dependencies are
+used, without leaking over to other programs.
 
 Set up venv and source `activate`.  The following example works on
 Linux, verified on [Linux Mint]():
@@ -48,8 +79,9 @@ we'll now use to install the requirements:
 ...
 ```
 
-> When done, call `deactivate`, or `deactivate.bat` to "detach" from the
-> venv.
+> **TIP:** When your session with netconf-client is over, you can call
+> the `deactivate`, or `deactivate.bat` to "detach" your terminal from
+> from the venv, or just close your terminal for the same effect.
 
 #### IMPORTANT INFORMATION!
 
@@ -92,3 +124,4 @@ license.
 [1]: https://linuxmint.com/
 [2]: https://gitforwindows.org/
 [3]: https://choosealicense.com/licenses/mit/
+[4]: https://github.com/microsoft/terminal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# Note: 'tkinter' is part of the standard Python distribution and must
+#       on Linux or macOS be installed via the system package manager.
 async-timeout==4.0.3
 bcrypt==4.1.3
 cffi==1.16.0


### PR DESCRIPTION
Apparently on Linux and macOS, the Python distribution files are split up in multiple packages.  This is not the case on Windows, so these instructions are not needed there.