### PR TITLE
fix(cfg): change default server_path to home directory

### DIFF
--- a/simple_netconf_client/network/Netconf.py
+++ b/simple_netconf_client/network/Netconf.py
@@ -77,7 +77,7 @@ class ConfigManager:
             'zoom': "100%",
             'server_iface': 'virbr0',
             'server_enabled': False,
-            'server_path': '',
+            'server_path': os.path.expanduser('~'),
             'server_port': 8080
         }
         self.cfg = self.default_cfg.copy()


### PR DESCRIPTION
Before this change, the `server_path` would default to an empty string, which causes the `File -> Open` menu item not to work, I'm assuming due to `""` not being a valid directory.

In order for this change to apply, the current configuration file should first be removed, or the `server_path` key should be removed from it.